### PR TITLE
feat: Add Experience Page

### DIFF
--- a/src/views/ExperiencePage.vue
+++ b/src/views/ExperiencePage.vue
@@ -1,9 +1,73 @@
-<template>
-  <p>Experience</p>
-</template>
+  <template>
+    <div class="flex flex-col text-green-400 w-11/12 space-y-4">
+      <h2 class="text-3xl font-bold mb-10">Mon expérience <span class="cursor"></span></h2>
+      <div class="flex flex-wrap gap-10">
+        <div
+            v-for="experience in experiences"
+            :key="experience.id"
+            class="p-6 bg-gray-600 rounded-lg shadow-lg hover:scale-110 transition transform duration-500 ease-in-out cursor-pointer w-full sm:w-1/2 lg:w-1/4"
+        >
+          <h2 class="text-xl font-bold">{{ experience.position }}</h2>
+          <h3 class="text-lg">{{ experience.employer }}</h3>
+          <p class="text-gray-500">{{ experience.year }}</p>
+          <p>{{ experience.description }}</p>
+          <ul class="list-disc list-inside mt-2">
+            <li v-for="fact in experience.keyFacts" :key="fact">{{ fact }}</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </template>
 
 <script>
 
+export default {
+  setup() {
+    const experiences = [
+      {
+        id: 1,
+        position: 'Développeur Full Stack',
+        employer: 'OpenAI',
+        year: '2020 - Présent',
+        description: 'Développement de solutions d\'IA de pointe.',
+        keyFacts: ['Travaillé sur le projet GPT-3', 'Contribué à diverses publications de recherche']
+      },
+      {
+        id: 2,
+        position: 'Ingénieur logiciel',
+        employer: 'Google',
+        year: '2018 - 2020',
+        description: 'Développement de nouvelles fonctionnalités pour Google Search.',
+        keyFacts: ['Amélioré le temps de chargement de la page de recherche', 'Contribué à l\'initiative AMP']
+      },
+      {
+        id: 3,
+        position: 'Ingénieur logiciel',
+        employer: 'Google',
+        year: '2018 - 2020',
+        description: 'Développement de nouvelles fonctionnalités pour Google Search.',
+        keyFacts: ['Amélioré le temps de chargement de la page de recherche', 'Contribué à l\'initiative AMP']
+      },
+      {
+        id: 4,
+        position: 'Ingénieur logiciel',
+        employer: 'Google',
+        year: '2018 - 2020',
+        description: 'Développement de nouvelles fonctionnalités pour Google Search.',
+        keyFacts: ['Amélioré le temps de chargement de la page de recherche', 'Contribué à l\'initiative AMP']
+      },
+      {
+        id: 5,
+        position: 'Ingénieur logiciel',
+        employer: 'Google',
+        year: '2018 - 2020',
+        description: 'Développement de nouvelles fonctionnalités pour Google Search.',
+        keyFacts: ['Amélioré le temps de chargement de la page de recherche', 'Contribué à l\'initiative AMP']
+      }
+    ]
+    return {experiences}
+  }
+}
 </script>
 
 <style>

--- a/tests/unit/ExperiencePage.test.js
+++ b/tests/unit/ExperiencePage.test.js
@@ -1,0 +1,70 @@
+import { mount } from '@vue/test-utils'
+import ExperiencePage from '@/views/ExperiencePage.vue'
+
+describe('ExperiencePage.vue', () => {
+    const experiences = [
+        {
+            id: 1,
+            position: 'Développeur Full Stack',
+            employer: 'OpenAI',
+            year: '2020 - Présent',
+            description: 'Développement de solutions d\'IA de pointe.',
+            keyFacts: ['Travaillé sur le projet GPT-3', 'Contribué à diverses publications de recherche']
+        },
+        {
+            id: 2,
+            position: 'Ingénieur logiciel',
+            employer: 'Google',
+            year: '2018 - 2020',
+            description: 'Développement de nouvelles fonctionnalités pour Google Search.',
+            keyFacts: ['Amélioré le temps de chargement de la page de recherche', 'Contribué à l\'initiative AMP']
+        },
+        {
+            id: 3,
+            position: 'Ingénieur logiciel',
+            employer: 'Google',
+            year: '2018 - 2020',
+            description: 'Développement de nouvelles fonctionnalités pour Google Search.',
+            keyFacts: ['Amélioré le temps de chargement de la page de recherche', 'Contribué à l\'initiative AMP']
+        },
+        {
+            id: 4,
+            position: 'Ingénieur logiciel',
+            employer: 'Google',
+            year: '2018 - 2020',
+            description: 'Développement de nouvelles fonctionnalités pour Google Search.',
+            keyFacts: ['Amélioré le temps de chargement de la page de recherche', 'Contribué à l\'initiative AMP']
+        },
+        {
+            id: 5,
+            position: 'Ingénieur logiciel',
+            employer: 'Google',
+            year: '2018 - 2020',
+            description: 'Développement de nouvelles fonctionnalités pour Google Search.',
+            keyFacts: ['Amélioré le temps de chargement de la page de recherche', 'Contribué à l\'initiative AMP']
+        }
+    ]
+
+    const wrapper = mount(ExperiencePage, {
+        data() {
+            return { experiences }
+        }
+    })
+
+    it('renders the title', () => {
+        expect(wrapper.find('h2').text()).toContain('Mon expérience')
+    })
+
+    it('renders the correct number of experience cards', () => {
+        const cards = wrapper.findAll('.p-6')
+        expect(cards.length).toBe(experiences.length)
+    })
+
+    it('renders the experience details correctly', () => {
+        const firstCard = wrapper.find('.p-6')
+        expect(firstCard.text()).toContain(experiences[0].position)
+        expect(firstCard.text()).toContain(experiences[0].employer)
+        expect(firstCard.text()).toContain(experiences[0].year)
+        expect(firstCard.text()).toContain(experiences[0].description)
+    })
+})


### PR DESCRIPTION
In this commit, I've added an Experience page that showcases various professional experiences. Each experience is displayed in a card containing detailed information about the position, employer, years of service, a brief job description, and key points. The layout is responsive and adapts to various screen sizes. Moreover, on hover, the experience cards get highlighted by slightly enlarging. 
